### PR TITLE
Fix broken turbolifts.

### DIFF
--- a/code/game/g_cmds.c
+++ b/code/game/g_cmds.c
@@ -4917,7 +4917,7 @@ static void Cmd_Turbolift_f(gentity_t* ent)
         return;
     }
 
-    trap_Argv(1, arg, sizeof(arg));
+    trap_Argv(2, arg, sizeof(arg));
 
     if (!arg[0])
     {


### PR DESCRIPTION
Commit on 3/11/2017 broke turbolift map entities. Reverted change to restore functionality.